### PR TITLE
Loops supports

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,22 @@ wsdirector script.yml ws://websocket.server:9876 -s 10
 #=> Group listeners: 20 clients, 0 failures
 ```
 
+Also you can add a loop option for your scenarios to avoid copy-paste actions:
+
+```yml
+  # script.yml
+  - client: # first clients group
+      name: "publisher" # optional group name
+      loop:
+        multiplier: ":scale" # :scale take number from -s param, and run :scale number of clients in this group
+        actions:
+          - receive:
+              data: "Welcome"
+          - wait_all # makes all clients in all groups wait untill every client get this point (global barrier)
+          - send:
+              data: "test message"
+```
+
 The simpliest scenario is just checking that socket is succesfully connected:
 
 ```yml

--- a/lib/wsdirector/scenario_reader.rb
+++ b/lib/wsdirector/scenario_reader.rb
@@ -13,8 +13,10 @@ module WSDirector
 
         if contents.first.key?("client")
           parse_multiple_scenarios(contents)
+        elsif contents.map(&:keys).flatten.include?("loop")
+          parse_loop_scenarios(contents)
         else
-          {"total" => 1, "clients" => [parse_simple_scenario(contents)]}
+          {"total" => 1, "clients" => [parse_scenario(contents)]}
         end
       end
 
@@ -35,13 +37,13 @@ module WSDirector
         end
       end
 
-      def parse_simple_scenario(
+      def parse_scenario(
         steps,
-        multiplier: 1, name: "default", ignore: nil, protocol: "base"
+        multiplier: 1, name: "default", ignore: nil, protocol: "base", loop: false
       )
         {
           "multiplier" => multiplier,
-          "steps" => handle_steps(steps),
+          "steps" => loop ? handle_loop_steps(steps, multiplier) : handle_steps(steps),
           "name" => name,
           "ignore" => ignore,
           "protocol" => protocol
@@ -50,21 +52,87 @@ module WSDirector
 
       def parse_multiple_scenarios(definitions)
         total_count = 0
-        clients = definitions.map.with_index do |client, i|
+        clients = []
+
+        definitions.each_with_index do |client, i|
           _, client = client.to_a.first
-          multiplier = parse_multiplier(client.delete("multiplier") || "1")
           name = client.delete("name") || (i + 1).to_s
-          total_count += multiplier
           ignore = parse_ingore(client.fetch("ignore", nil))
-          parse_simple_scenario(
-            client.fetch("actions", []),
-            multiplier: multiplier,
-            name: name,
-            ignore: ignore,
-            protocol: client.fetch("protocol", "base")
-          )
+          protocol = client.fetch("protocol", "base")
+
+          if client.key?("loop")
+            parsed_scenarios = parse_loop_scenarios(
+              [client],
+              name: name,
+              ignore: ignore,
+              protocol: protocol
+            )
+            total_count += parsed_scenarios["total"].to_i
+
+            clients << parsed_scenarios["clients"].first
+          else
+            multiplier = parse_multiplier(client.delete("multiplier") || "1")
+            total_count += multiplier
+
+            clients << parse_scenario(
+              client.fetch("actions", []),
+              multiplier: multiplier,
+              name: name,
+              ignore: ignore,
+              protocol: protocol
+            )
+          end
         end
+
         {"total" => total_count, "clients" => clients}
+      end
+
+      def parse_loop_scenarios(scenario_steps, name: "default", ignore: nil, protocol: "base")
+        total_count = 0
+        parsed_steps = []
+
+        scenario_steps.each do |scenario_step|
+          if scenario_step.key?("loop")
+            loop_scenario = scenario_step["loop"]
+            multiplier = parse_multiplier(loop_scenario["multiplier"] || "1")
+            loop_actions = loop_scenario["actions"] || []
+            total_count += loop_actions.size.zero? ? multiplier : loop_actions.size * multiplier
+
+            parsed_steps << parse_scenario(
+              loop_actions,
+              name: name,
+              ignore: ignore,
+              multiplier: multiplier,
+              protocol: protocol,
+              loop: true
+            )
+          else
+            total_count += 1
+            parsed_steps << parse_scenario([scenario_step])
+          end
+        end
+
+        {"total" => total_count, "clients" => parsed_steps}
+      end
+
+      def handle_loop_steps(steps, multiplier)
+        current_id = 0
+        handled_steps = []
+
+        1.upto(multiplier) do |_i|
+          steps.each do |current_step|
+            if current_step.is_a?(Hash)
+              type, data = current_step.to_a.first
+              handled_steps << {"type" => type, "id" => current_id}.merge(data)
+              current_id += 1
+            else
+              handled_steps << {"type" => current_step, "id" => current_id}
+              current_id += 1
+            end
+          end
+        end
+
+        handled_steps
       end
 
       def parse_ingore(str)

--- a/lib/wsdirector/version.rb
+++ b/lib/wsdirector/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module WSDirector
-  VERSION = "0.4.0"
+  VERSION = "0.5.0"
 end

--- a/spec/fixtures/scenario_loop_multiple.yml
+++ b/spec/fixtures/scenario_loop_multiple.yml
@@ -1,0 +1,54 @@
+- client:
+    ignore: !ruby/regexp /ping/
+    loop:
+      multiplier: 3
+      actions:
+        - receive:
+            data:
+              type: "welcome"
+        - send:
+            data:
+              command: "subscribe"
+              identifier: "{\"channel\":\"TestChannel\"}"
+        - receive:
+            data:
+              identifier: "{\"channel\":\"TestChannel\"}"
+              type: "confirm_subscription"
+        - wait_all
+        - send:
+            data:
+              command: "message"
+              identifier: "{\"channel\":\"TestChannel\"}"
+              data: "{\"text\": \"echo\",\"action\":\"broadcast\"}"
+        - send:
+            data:
+              command: "message"
+              identifier: "{\"channel\":\"TestChannel\"}"
+              data: "{\"text\": \"echo 2\",\"action\":\"broadcast\"}"
+        - send:
+            data:
+              command: "message"
+              identifier: "{\"channel\":\"TestChannel\"}"
+              data: "{\"text\": \"echo 3\",\"action\":\"broadcast\"}"
+
+- client:
+    name: "listeners"
+    ignore:
+      - !ruby/regexp /ping/
+    loop:
+      multiplier: ":scale * 2"
+      actions:
+        - receive:
+            data:
+              type: "welcome"
+        - send:
+            data:
+              command: "subscribe"
+              identifier: "{\"channel\":\"TestChannel\"}"
+        - receive:
+            data:
+              identifier: "{\"channel\":\"TestChannel\"}"
+              type: "confirm_subscription"
+        - wait_all
+        - receive:
+            multiplier: ":scale + :scale + 1"

--- a/spec/fixtures/scenario_loop_simple.yml
+++ b/spec/fixtures/scenario_loop_simple.yml
@@ -1,0 +1,25 @@
+- receive:
+    data:
+      type: "welcome"
+- loop:
+    multiplier: 3
+    actions:
+      - send:
+          data:
+            command: "subscribe"
+            identifier: "{\"channel\":\"TestChannel\"}"
+      - receive:
+          data:
+            identifier: "{\"channel\":\"TestChannel\"}"
+            type: "confirm_subscription"
+      - send:
+          data:
+            command: "message"
+            identifier: "{\"channel\":\"TestChannel\"}"
+            data: "{\"text\": \"echo\",\"action\":\"echo\"}"
+      - receive:
+          data:
+            identifier: "{\"channel\":\"TestChannel\"}"
+            message:
+              text: "echo"
+              action: "echo"

--- a/spec/wsdirector/scenario_reader_spec.rb
+++ b/spec/wsdirector/scenario_reader_spec.rb
@@ -46,6 +46,61 @@ describe WSDirector::ScenarioReader do
     end
   end
 
+  context "with loop option" do
+    context "and scenario is simple" do
+      let(:file_path) { fixture_path("scenario_loop_simple.yml") }
+
+      it "contains one looped client", :aggregate_failures do
+        expect(subject["total"]).to eq(13)
+        expect(subject["clients"].first["name"]).to eq "default"
+        expect(subject["clients"].first["steps"].size).to eq 1
+        expect(subject["clients"].first["multiplier"]).to eq 1
+        expect(subject["clients"].first["steps"].first["type"]).to eq "receive"
+
+        expect(subject["clients"].last["name"]).to eq "default"
+        expect(subject["clients"].last["steps"].size).to eq 12
+        expect(subject["clients"].last["multiplier"]).to eq 3
+        expect(subject["clients"].last["steps"].first["type"]).to eq "send"
+      end
+    end
+
+    context "and scenario with multiple clients" do
+      let(:file_path) { fixture_path("scenario_loop_multiple.yml") }
+
+      it "contains multiple looped clients", :aggregate_failures do
+        expect(subject["total"]).to eq(31)
+        expect(subject["clients"].size).to eq 2
+
+        expect(subject["clients"].first["name"]).to eq "1"
+        expect(subject["clients"].first["ignore"]).to eq([/ping/])
+        expect(subject["clients"].first["steps"].size).to eq 21
+        expect(subject["clients"].first["multiplier"]).to eq 3
+        expect(subject["clients"].first["steps"].last["type"]).to eq "send"
+
+        expect(subject["clients"].last["name"]).to eq "listeners"
+        expect(subject["clients"].last["ignore"]).to eq([/ping/])
+        expect(subject["clients"].last["steps"].size).to eq 10
+        expect(subject["clients"].last["multiplier"]).to eq 2
+        expect(subject["clients"].last["steps"].last["type"]).to eq "receive"
+      end
+
+      context "with scale" do
+        before { WSDirector.config.scale = 5 }
+
+        it "parses multipliers", :aggregate_failures do
+          expect(subject["total"]).to eq 71
+          expect(subject["clients"].size).to eq(2)
+
+          expect(subject["clients"].first["multiplier"]).to eq 3
+          expect(subject["clients"].first["steps"].size).to eq 21
+
+          expect(subject["clients"].last["multiplier"]).to eq 10
+          expect(subject["clients"].last["steps"].size).to eq 50
+        end
+      end
+    end
+  end
+
   context "with ERB" do
     let(:file_path) { fixture_path("scenario_erb.yml") }
 


### PR DESCRIPTION
<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

## What is the purpose of this pull request?

<!--
  If it's a bug fix, then link it to the issue, for example:

  Fixes #xxx
-->

Make it possible to avoid copy-paste repetitive scenarios, for example:

before
```yml
- receive:
    data:
      type: "Welcome"
- send:
    data: "send message"
- receive:
    data: "receive message"
... # skip 100+ copy-paste rows
- send:
    data: "send message"
- receive:
    data: "receive message"
```

after
```yml
- receive:
    data:
      type: "Welcome"
- loop:
  multiplier: 100
  actions:
    - send:
        data: "send message"
    - receive:
        data: "receive message"
```

## Is there anything you'd like reviewers to focus on?

On changes in the current logic

## Checklist

- [ ] I've added tests for this change
- [ ] I've added a Changelog entry
- [ ] I've updated a documentation
