### PR TITLE
loop option support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 ## master
 
+- Add loop option support. ([@last-in-japan][])
+
+You can specify a `loop` option to perform a similar set of actions multiple times:
+
+```yml
+  # script.yml
+  - client:
+      name: "listeners"
+      loop:
+        multiplier: ":scale" # :scale take number from -s param, and run :scale number of clients in this group
+        actions:
+          - receive:
+              data:
+                type: "welcome"
+          - send:
+              data:
+                command: "subscribe"
+                identifier: "{\"channel\":\"Channel\"}"
+          - receive:
+              data:
+                identifier: "{\"channel\":\"Channel\"}"
+                type: "confirm_subscription"
+          - wait_all
+          - receive:
+              multiplier: ":scale + 1"
+```
+
+Useful in combination with `:scale`.
+
 ## 0.4.0 (2020-08-24)
 
 - **Drop Ruby 2.4 support**. ([@palkan][])

--- a/README.md
+++ b/README.md
@@ -77,6 +77,31 @@ The simpliest scenario is just checking that socket is succesfully connected:
   # no actions
 ```
 
+Run with loop option:
+
+```yml
+  # script.yml
+  - client:
+      name: "listeners"
+      loop:
+        multiplier: ":scale" # :scale take number from -s param, and run :scale number of clients in this group
+        actions:
+          - receive:
+              data:
+                type: "welcome"
+          - send:
+              data:
+                command: "subscribe"
+                identifier: "{\"channel\":\"Channel\"}"
+          - receive:
+              data:
+                identifier: "{\"channel\":\"Channel\"}"
+                type: "confirm_subscription"
+          - wait_all
+          - receive:
+              multiplier: ":scale + 1"
+```
+
 ### Protocols
 
 WSDirector uses protocols to handle different actions.

--- a/lib/wsdirector/ext/deep_dup.rb
+++ b/lib/wsdirector/ext/deep_dup.rb
@@ -29,6 +29,12 @@ module WSDirector
           end
         end
       end
+
+      refine ::Object do
+        def deep_dup
+          dup
+        end
+      end
     end
   end
 end

--- a/spec/fixtures/scenario_multiple_loop.yml
+++ b/spec/fixtures/scenario_multiple_loop.yml
@@ -1,0 +1,55 @@
+- client:
+    ignore: !ruby/regexp /ping/
+    loop:
+      multiplier: 3
+      actions:
+        - receive:
+            data:
+              type: "welcome"
+        - send:
+            data:
+              command: "subscribe"
+              identifier: "{\"channel\":\"TestChannel\"}"
+        - receive:
+            data:
+              identifier: "{\"channel\":\"TestChannel\"}"
+              type: "confirm_subscription"
+        - wait_all
+        - send:
+            data:
+              command: "message"
+              identifier: "{\"channel\":\"TestChannel\"}"
+              data: "{\"text\": \"echo\",\"action\":\"broadcast\"}"
+        - send:
+            data:
+              command: "message"
+              identifier: "{\"channel\":\"TestChannel\"}"
+              data: "{\"text\": \"echo 2\",\"action\":\"broadcast\"}"
+        - send:
+            data:
+              command: "message"
+              identifier: "{\"channel\":\"TestChannel\"}"
+              data: "{\"text\": \"echo 3\",\"action\":\"broadcast\"}"
+
+- client:
+    name: "listeners"
+    ignore:
+      - !ruby/regexp /ping/
+    loop:
+      multiplier: ":scale * 2"
+      actions:
+        - receive:
+            data:
+              type: "welcome"
+        - send:
+            data:
+              command: "subscribe"
+              identifier: "{\"channel\":\"TestChannel\"}"
+        - receive:
+            data:
+              identifier: "{\"channel\":\"TestChannel\"}"
+              type: "confirm_subscription"
+        - wait_all
+        - receive:
+            multiplier: ":scale + :scale + 1"
+

--- a/spec/fixtures/scenario_simple_loop.yml
+++ b/spec/fixtures/scenario_simple_loop.yml
@@ -1,0 +1,26 @@
+- receive:
+    data:
+      type: "welcome"
+- loop:
+    multiplier: 3
+    actions:
+      - send:
+          data:
+            command: "subscribe"
+            identifier: "{\"channel\":\"TestChannel\"}"
+      - receive:
+          data:
+            identifier: "{\"channel\":\"TestChannel\"}"
+            type: "confirm_subscription"
+      - send:
+          data:
+            command: "message"
+            identifier: "{\"channel\":\"TestChannel\"}"
+            data: "{\"text\": \"echo\",\"action\":\"echo\"}"
+      - receive:
+          data:
+            identifier: "{\"channel\":\"TestChannel\"}"
+            message:
+              text: "echo"
+              action: "echo"
+


### PR DESCRIPTION
<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

## What is the purpose of this pull request?
To add `loop` option to perform a similar set of actions multiple times - https://github.com/palkan/wsdirector/issues/7

With this option you can run set of multiple actions in such way:
```yml
  # script.yml
  - client:
      name: "listeners"
      loop:
        multiplier: ":scale" # :scale take number from -s param, and run :scale number of clients in this group
        actions:
          - receive:
              data:
                type: "welcome"
          - send:
              data:
                command: "subscribe"
                identifier: "{\"channel\":\"Channel\"}"
          - receive:
              data:
                identifier: "{\"channel\":\"Channel\"}"
                type: "confirm_subscription"
          - wait_all
          - receive:
              multiplier: ":scale + 1"
```


<!--
  If it's a bug fix, then link it to the issue, for example:

  Fixes #xxx
-->

## Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation
