### PR TITLE
JSON scenarios supports

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Create YAML file with simple testing script:
 and run it with this command:
 
 ```bash
-wsdirector script.yml -u ws://websocket.server:9876/ws
+wsdirector script.yml ws://websocket.server:9876/ws
 
 #=> 1 clients, 0 failures
 ```
@@ -63,7 +63,7 @@ You can create more complex scenarios with multiple client groups:
 Run with scale factor:
 
 ```bash
-wsdirector script.yml -u ws://websocket.server:9876 -s 10
+wsdirector script.yml ws://websocket.server:9876 -s 10
 
 #=> Group publisher: 10 clients, 0 failures
 #=> Group listeners: 20 clients, 0 failures

--- a/lib/wsdirector/cli.rb
+++ b/lib/wsdirector/cli.rb
@@ -39,6 +39,9 @@ module WSDirector
 
     private
 
+    FILE_FORMAT = /.+.(json|yml)\z/.freeze
+    private_constant :FILE_FORMAT
+
     def parse_args!
       # rubocop: disable Metrics/LineLength
       parser = OptionParser.new do |opts|
@@ -72,22 +75,26 @@ module WSDirector
       # rubocop: enable Metrics/LineLength
 
       parser.parse!
+
+      WSDirector.config.scenario_path = ARGV.grep(FILE_FORMAT).last
+
+      unless WSDirector.config.ws_url
+        WSDirector.config.ws_url = ARGV.grep(URI::DEFAULT_PARSER.make_regexp).last
+      end
+
       check_for_errors
     end
 
     def check_for_errors
-      WSDirector.config.scenario_path = ARGV[0]
-
       if WSDirector.config.json_scenario.nil?
-        raise(Error, "Scenario is missing") if WSDirector.config.scenario_path.nil?
+        raise(Error, "Scenario is missing") unless WSDirector.config.scenario_path
 
         unless File.file?(WSDirector.config.scenario_path)
           raise(Error, "File doesn't exist #{WSDirector.config.scenario_path}")
         end
       end
 
-      raise(Error, "Websocket server url is missing") if WSDirector.config.ws_url.nil?
-      raise(Error, "Invalid websocket server url") unless WSDirector.config.ws_url.match?(URI::DEFAULT_PARSER.make_regexp)
+      raise(Error, "Websocket server url is missing") unless WSDirector.config.ws_url
     end
   end
 end

--- a/lib/wsdirector/client.rb
+++ b/lib/wsdirector/client.rb
@@ -60,7 +60,7 @@ module WSDirector
 
     def ignored?(msg)
       return false unless @ignore
-      @ignore.any? { |pattern| msg =~ pattern }
+      @ignore.any? { |pattern| msg =~ Regexp.new(pattern) }
     end
   end
 end

--- a/lib/wsdirector/scenario_reader.rb
+++ b/lib/wsdirector/scenario_reader.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "erb"
+require "json"
 require "wsdirector/ext/deep_dup"
 
 module WSDirector
@@ -14,7 +15,7 @@ module WSDirector
       def parse(scenario)
         contents =
           if File.file?(scenario)
-            ::YAML.load(ERB.new(File.read(scenario)).result) # rubocop:disable Security/YAMLLoad
+            parse_file(scenario)
           else
             [JSON.parse(scenario)]
           end.flatten
@@ -29,6 +30,17 @@ module WSDirector
       end
 
       private
+
+      JSON_FILE_FORMAT = /.+.(json)\z/.freeze
+      private_constant :JSON_FILE_FORMAT
+
+      def parse_file(file)
+        if file.match?(JSON_FILE_FORMAT)
+          JSON.parse(File.read(file))
+        else
+          ::YAML.load(ERB.new(File.read(file)).result) # rubocop:disable Security/YAMLLoad
+        end
+      end
 
       def handle_steps(steps)
         steps.flat_map.with_index do |step, id|

--- a/lib/wsdirector/version.rb
+++ b/lib/wsdirector/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module WSDirector
-  VERSION = "0.5.0"
+  VERSION = "0.4.0"
 end

--- a/spec/cases/cable_server_spec.rb
+++ b/spec/cases/cable_server_spec.rb
@@ -12,8 +12,6 @@ describe "wsdirector vs CableServer" do
 
   before { WSDirector.config.ws_url = CableServer.url }
 
-  let(:options) { "-u #{WSDirector.config.ws_url}" }
-
   context "just connect (no actions, no protocol)" do
     let(:content) do
       <<~YAML
@@ -23,7 +21,7 @@ describe "wsdirector vs CableServer" do
     end
 
     it "shows success message" do
-      expect(run_wsdirector(test_script, options: options)).to include "1 clients, 0 failures"
+      expect(run_wsdirector(test_script)).to include "1 clients, 0 failures"
     end
   end
 
@@ -37,7 +35,7 @@ describe "wsdirector vs CableServer" do
     end
 
     it "shows success message" do
-      expect(run_wsdirector(test_script, options: options)).to include "3 clients, 0 failures"
+      expect(run_wsdirector(test_script)).to include "3 clients, 0 failures"
     end
   end
 
@@ -82,10 +80,9 @@ describe "wsdirector vs CableServer" do
                     text: "Hello!"
       YAML
     end
-    let(:options) { super() + " -s 3" }
 
     it "shows success message", :aggregate_failures do
-      output = run_wsdirector(test_script, options: options)
+      output = run_wsdirector(test_script, options: "-s 3")
       expect(output).to include "Group publishers: 3 clients, 0 failures"
       expect(output).to include "Group listeners: 6 clients, 0 failures"
     end
@@ -144,10 +141,9 @@ describe "wsdirector vs CableServer" do
                     text: "Hello!"
       YAML
     end
-    let(:options) { super() + " -s 1" }
 
     it "shows success message", :aggregate_failures do
-      output = run_wsdirector(test_script, options: options)
+      output = run_wsdirector(test_script, options: "-s 1")
       expect(output).to include "Group publishers: 1 clients, 0 failures"
       expect(output).to include "Group listeners: 2 clients, 0 failures"
     end
@@ -181,7 +177,7 @@ describe "wsdirector vs CableServer" do
     end
 
     it "shows failure message", :aggregate_failures do
-      output = run_wsdirector(test_script, failure: true, options: options)
+      output = run_wsdirector(test_script, failure: true)
       expect(output).to include "Group 1: 1 clients, 1 failures"
       expect(output).to include "Group 2: 1 clients, 1 failures"
       expect(output).to include "Subscription rejected to"
@@ -246,10 +242,9 @@ describe "wsdirector vs CableServer" do
                         text: "..."
       YAML
     end
-    let(:options) { super() + " -s 4" }
 
     it "shows success message", :aggregate_failures do
-      output = run_wsdirector(test_script, options: options)
+      output = run_wsdirector(test_script, options: "-s 4")
       expect(output).to include "4 clients, 0 failures"
     end
   end

--- a/spec/cases/echo_server_spec.rb
+++ b/spec/cases/echo_server_spec.rb
@@ -12,8 +12,6 @@ describe "wsdirector vs EchoServer" do
 
   before { WSDirector.config.ws_url = EchoServer.url }
 
-  let(:options) { "-u #{WSDirector.config.ws_url}" }
-
   context "just connect (no actions)" do
     let(:content) do
       <<~YAML
@@ -23,7 +21,7 @@ describe "wsdirector vs EchoServer" do
     end
 
     it "shows success message" do
-      expect(run_wsdirector(test_script, options: options)).to include "1 clients, 0 failures"
+      expect(run_wsdirector(test_script)).to include "1 clients, 0 failures"
     end
   end
 
@@ -38,7 +36,7 @@ describe "wsdirector vs EchoServer" do
     end
 
     it "shows success message" do
-      expect(run_wsdirector(test_script, options: options)).to include "1 clients, 0 failures"
+      expect(run_wsdirector(test_script)).to include "1 clients, 0 failures"
     end
   end
 
@@ -58,7 +56,7 @@ describe "wsdirector vs EchoServer" do
     end
 
     it "show failure message and errors", :aggregate_failures do
-      output = run_wsdirector(test_script, failure: true, options: options)
+      output = run_wsdirector(test_script, failure: true)
       expect(output).to include "1 clients, 1 failures"
       expect(output).to include("1) Action failed: #receive")
       expect(output).to match(/-- expected: .*subscription_confirmation/)

--- a/spec/fixtures/json/scenario_multiple.json
+++ b/spec/fixtures/json/scenario_multiple.json
@@ -2,7 +2,7 @@
   {
     "client": {
       "multiplier": ":scale",
-      "ignore": !ruby/regexp /ping/,
+      "ignore": "ping",
       "actions": [
         {
           "receive": {
@@ -62,7 +62,7 @@
     "client": {
       "multiplier": ":scale * 2",
       "name": "listeners",
-      "ignore": !ruby/regexp /ping/,
+      "ignore": "ping",
       "actions": [
         {
           "receive": {

--- a/spec/fixtures/json/scenario_simple_loop.json
+++ b/spec/fixtures/json/scenario_simple_loop.json
@@ -1,0 +1,52 @@
+[
+  {
+    "receive": {
+      "data": {
+        "type": "welcome"
+      }
+    }
+  },
+  {
+    "loop": {
+      "multiplier": 3,
+      "actions": [
+        {
+          "send": {
+            "data": {
+              "command": "subscribe",
+              "identifier": "{\"channel\":\"TestChannel\"}"
+            }
+          }
+        },
+        {
+          "receive": {
+            "data": {
+              "identifier": "{\"channel\":\"TestChannel\"}",
+              "type": "confirm_subscription"
+            }
+          }
+        },
+        {
+          "send": {
+            "data": {
+              "command": "message",
+              "identifier": "{\"channel\":\"TestChannel\"}",
+              "data": "{\"text\": \"echo\",\"action\":\"echo\"}"
+            }
+          }
+        },
+        {
+          "receive": {
+            "data": {
+              "identifier": "{\"channel\":\"TestChannel\"}",
+              "message": {
+                "text": "echo",
+                "action": "echo"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+]

--- a/spec/support/integration_helper.rb
+++ b/spec/support/integration_helper.rb
@@ -8,7 +8,7 @@ module IntegrationHelpers
 
     output, err, status = Open3.capture3(
       env,
-      "bundle exec #{cli_path} #{scenario_path} #{options}",
+      "bundle exec #{cli_path} #{scenario_path} #{WSDirector.config.ws_url} #{options}",
       chdir: chdir || File.expand_path("../fixtures", __dir__)
     )
     expect(status).to be_success, "Test #{scenario_path} #{options} failed with: #{err}" if success && !failure

--- a/spec/wsdirector/scenario_reader_spec.rb
+++ b/spec/wsdirector/scenario_reader_spec.rb
@@ -59,7 +59,7 @@ describe WSDirector::ScenarioReader do
   end
 
   context "when single client with loop inside" do
-    let(:file_path) { fixture_path("scenario_simple_loop.yml") }
+    let(:scenario) { fixture_path("scenario_simple_loop.yml") }
 
     it "multiplies actions depending on multiplier from a loop" do
       expect(subject["total"]).to eq(1)
@@ -71,7 +71,7 @@ describe WSDirector::ScenarioReader do
   end
 
   context "when multiple clients with loop inside" do
-    let(:file_path) { fixture_path("scenario_multiple_loop.yml") }
+    let(:scenario) { fixture_path("scenario_multiple_loop.yml") }
 
     it "multiplies actions depending on multiplier from a loop" do
       expect(subject["total"]).to eq(2)
@@ -132,16 +132,28 @@ describe WSDirector::ScenarioReader do
       it "contains two clients", :aggregate_failures do
         expect(subject["total"]).to eq(3)
         expect(subject["clients"].first["name"]).to eq "1"
-        expect(subject["clients"].first["ignore"]).to eq([/ping/])
+        expect(subject["clients"].first["ignore"]).to eq(["ping"])
         expect(subject["clients"].size).to eq 2
         expect(subject["clients"].first["steps"].size).to eq 7
         expect(subject["clients"].first["multiplier"]).to eq 1
         expect(subject["clients"].first["steps"].last["type"]).to eq "send"
         expect(subject["clients"].last["steps"].size).to eq 7
         expect(subject["clients"].last["name"]).to eq "listeners"
-        expect(subject["clients"].last["ignore"]).to eq([/ping/])
+        expect(subject["clients"].last["ignore"]).to eq(["ping"])
         expect(subject["clients"].last["multiplier"]).to eq 2
         expect(subject["clients"].last["steps"][3]["type"]).to eq "wait_all"
+      end
+    end
+
+    context "with loop inside" do
+      let(:scenario) { fixture_path("json/scenario_simple_loop.json") }
+
+      it "contains two clients", :aggregate_failures do
+        expect(subject["total"]).to eq(1)
+        expect(subject["clients"].first["name"]).to eq "default"
+        expect(subject["clients"].first["steps"].size).to eq 13
+        expect(subject["clients"].first["multiplier"]).to eq 1
+        expect(subject["clients"].first["steps"].first["type"]).to eq "receive"
       end
     end
   end


### PR DESCRIPTION
<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

## What is the purpose of this pull request?

Add JSON support to solve this issue https://github.com/palkan/wsdirector/issues/10

You can pass a JSON scenario directly to the CLI without creating a file:

```bash
wsdirector -i '[{"receive": {"data":"welcome"}},{"send":{"data":"send message"}},{"receive":{"data":"receive message"}}]' -u ws://websocket.server:9876
```

or you can pass it as a JSON file:

```bash
wsdirector scenario.json -u ws://websocket.server:9876
```

Also, I don't know if this is good or bad, but I removed passing a WS url as part of args and made it only available from CLI with opiton `-u` 🤔 

<!--
  If it's a bug fix, then link it to the issue, for example:

  Fixes #xxx
-->

## Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation
